### PR TITLE
Erweiterung SerialCommunication

### DIFF
--- a/CanLogger/include/serial/SerialCommunication.hpp
+++ b/CanLogger/include/serial/SerialCommunication.hpp
@@ -16,16 +16,21 @@ public:
     SerialCommunication(HardwareSerial& serial);
     
     void workWith(HardwareSerial& serial);
-    void print(String const& message) const ;
-    void println(String const& message) const;
-    SerialCommunication const& operator<<(String const& message) const;
-    SerialCommunication const& operator<<(char const& message) const;
+    // Ausgabe einer normalen Nachricht - ohne Zeilenumbruch
+    template<typename T>
+    void print(T const& message) const ;
+    // Ausgabe einer normalen Nachricht - mit Zeilenumbruch
+    template<typename T>
+    void println(T const& message) const;
+    // Ausgabe einer normalen Nachricht - ohne Zeilenumbruch
+    template<typename T>
+    SerialCommunication const& operator<<(T const& message) const;
     // Ausgabe einer Fehlermeldung
     void printError(String const& message) const;
     // Ausgabe von Debugnachrichten
     void printDebug(String const& message) const;
+    // Aktivierung/Deaktivierung von Debugnachrichten
     void showDebugMessages(bool mode);
-
 };
 
 
@@ -35,6 +40,7 @@ namespace utilities
     extern SerialCommunication scom;
 }
 
+#include "serial/SerialCommunication.inl"
 
 
 #endif

--- a/CanLogger/include/serial/SerialCommunication.inl
+++ b/CanLogger/include/serial/SerialCommunication.inl
@@ -1,0 +1,32 @@
+#include "serial/SerialCommunication.hpp"
+
+template<typename T>
+void SerialCommunication::print(T const& message) const
+{
+    if(this->serial == nullptr)
+    {
+        return;
+    }
+    this->serial->print(message);
+}
+
+template<typename T>
+void SerialCommunication::println(T const& message) const
+{
+    if(this->serial == nullptr)
+    {
+        return;
+    }
+    this->serial->println(message);
+}
+
+template<typename T>
+SerialCommunication const& SerialCommunication::operator<<(T const& message) const
+{
+    if(this->serial == nullptr)
+    {
+        return *this;
+    }
+    this->serial->print(message);
+    return *this;
+}

--- a/CanLogger/src/serial/SerialCommunication.cpp
+++ b/CanLogger/src/serial/SerialCommunication.cpp
@@ -14,44 +14,6 @@ void SerialCommunication::workWith(HardwareSerial& serial)
     this->serial = &serial;
 }
 
-void SerialCommunication::print(String const& message) const
-{
-    if(this->serial == nullptr)
-    {
-        return;
-    }
-    this->serial->print(message);
-}
-
-void SerialCommunication::println(String const& message) const
-{
-    if(this->serial == nullptr)
-    {
-        return;
-    }
-    this->serial->println(message);
-}
-
-SerialCommunication const& SerialCommunication::operator<<(String const& message) const
-{
-    if(this->serial == nullptr)
-    {
-        return *this;
-    }
-    this->serial->print(message);
-    return *this;
-}
-
-SerialCommunication const& SerialCommunication::operator<<(char const& message) const
-{
-    if(this->serial == nullptr)
-    {
-        return *this;
-    }
-    this->serial->print(message);
-    return *this;
-}
-
 void SerialCommunication::printError(String const& message) const
 {
     if(this->serial == nullptr)


### PR DESCRIPTION
Durch Templates, kann SerialCommunication alle Datentypen entgegennehmen die die Klasse Serial standardmäßig verwalten kann.