### PR TITLE
Korrektur getEncoderPos()

### DIFF
--- a/CanLogger/src/buttons/Encoder.cpp
+++ b/CanLogger/src/buttons/Encoder.cpp
@@ -40,7 +40,7 @@ void doEncoderA()
     }
   
     alteZeitEncoder = millis();
-    scom.println(encoderPos); // später auskommentieren
+    scom << encoderPos << endz; // später auskommentieren
    }
 }
 
@@ -75,7 +75,7 @@ void initEncoder()
 }
 
 // Gibt die aktuelle position des Encoders zurück
-int getEncoderValue()
+int getEncoderPos()
 {
   encoderPosChanged = false;
   return encoderPos;

--- a/CanLogger/src/main.cpp
+++ b/CanLogger/src/main.cpp
@@ -19,11 +19,10 @@ void setup() {
   scom.showDebugMessages(true); // Debugmodus einschalten
   
   init_SD();
-
   initEncoder();
   initTaster();
-  createNewCanLogFile();
 
+  createNewCanLogFile();
 
   display.begin();
   display.fillScreen(ILI9341_BLACK);


### PR DESCRIPTION
Name der Methode getEncoderPos() wurde geändert.