### PR TITLE
scom, GetFullId, variable Busgeschwindigkeit und processCanMessage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 
+.vscode/c_cpp_properties.json

--- a/CanLogger/include/can/CanUtility.hpp
+++ b/CanLogger/include/can/CanUtility.hpp
@@ -4,7 +4,18 @@
 
 #include <Arduino.h>
 
-HAL_StatusTypeDef CanUtility_Init(void);
+typedef enum
+{
+    //CAN_1000_KBIT   =   2 funktioniert zurzeit nicht /*transmisson speed of CAN-bus of 1000 kbit/s   */
+    CAN_500_KBIT    =   4,  /*transmisson speed of CAN-bus of 500 kbit/s    */
+    CAN_400_KBIT    =   5,  /*transmisson speed of CAN-bus of 400 kbit/s    */
+    CAN_250_KBIT    =   8,  /*transmisson speed of CAN-bus of 250 kbit/s    */
+    CAN_200_KBIT    =   10, /*transmisson speed of CAN-bus of 200 kbit/s    */
+    CAN_125_KBIT    =   16, /*transmisson speed of CAN-bus of 125 kbit/s    */
+    CAN_100_KBIT    =   20  /*transmisson speed of CAN-bus of 100 kbit/s    */
+} CAN_SpeedTypedef;
+
+HAL_StatusTypeDef CanUtility_Init(CAN_SpeedTypedef speed);
 HAL_StatusTypeDef CanUtility_DeInit(void);
 HAL_StatusTypeDef CanUtility_EnableRecieve(void);
 HAL_StatusTypeDef CanUtility_DissableRecieve(void);

--- a/CanLogger/include/can/Canmsg.hpp
+++ b/CanLogger/include/can/Canmsg.hpp
@@ -54,6 +54,7 @@ public:
 	// Get-Funktionen:
 	uint16_t GetStdIdentifier() const;
 	uint32_t GetExtIdentifier() const;
+	uint32_t GetFullId() const;
 	bool GetIsExtIdentifier() const;
 	bool GetRtr() const;
 	uint16_t GetTime() const;

--- a/CanLogger/include/display/screenBuffer.hpp
+++ b/CanLogger/include/display/screenBuffer.hpp
@@ -3,14 +3,23 @@
 
 #include "can/Canmsg.hpp"
 
+//Debug:
 void printScreenBufferSerial(void);
 void printScreenBufferUserViewSerial(void);
+
+//behandlung einzelner Nachrichten
 void sortCanMessageIntoBuffer(Canmsg const& msg);
 void insertMessageHere(Canmsg const& msg, int pos);
-void makeBufferVisible(void);
-void clearBuffer(void);
+
+// kopieren der Nachrichten aus dem back- zum frontendbuffer
+extern bool updateUserView;
+
+// initialisierungsfunktionen
 void screenBufferInit(void);
 void screenBufferDeinit(void);
+
+// loop zum bearbeiten der Nachrichten
+void loopScreenBuffer(void);
 
 constexpr int SCREEN_BUFFER_SIZE = 10;
 extern int screenBufferFillLevel;

--- a/CanLogger/include/utilities/utilities.hpp
+++ b/CanLogger/include/utilities/utilities.hpp
@@ -1,7 +1,6 @@
 #ifndef UTILITIES_HPP
 #define UTILITIES_HPP
 
-void processCanMessage(void);
 void AddZerosToString(String& s,uint64_t const val,uint64_t const maxVal, uint8_t const numberSys);
 
 #endif //UTILITIES_HPP

--- a/CanLogger/src/can/Canmsg.cpp
+++ b/CanLogger/src/can/Canmsg.cpp
@@ -1,6 +1,7 @@
 #include "can/Canmsg.hpp"
 #include "can/CanUtility.hpp"
 #include "utilities/utilities.hpp"
+#include "utilities/SerialCommunication.hpp"
 
 Canmsg* Canmsg_bufferCanRecMessages;
 int Canmsg_bufferCanRecPointer;
@@ -377,7 +378,7 @@ void Canmsg::Recieve(bool const fifo)
         }
         else
         {
-          Serial.println("CAN-Nachricht konnte nicht ausgelesen werden");
+          utilities::scom.printError("CAN-Nachricht konnte nicht ausgelesen werden");
         }
     }
 }
@@ -424,7 +425,7 @@ HAL_StatusTypeDef Canmsg::Send(void) const
 	}
   else
   {
-    Serial.println("CAN-Nachricht konnte nicht gesendet werden(Alle TX Mailboxen belegt).");
+    utilities::scom.printError("CAN-Nachricht konnte nicht gesendet werden(Alle TX Mailboxen belegt).");
     return HAL_ERROR;
   }
 }
@@ -445,6 +446,23 @@ uint16_t Canmsg::GetStdIdentifier() const
 uint32_t Canmsg::GetExtIdentifier() const
 {
   return this->extIdentifier;  
+}
+
+/* 
+    function to get the full Identifier of the CAN-message,
+    regardless whether it uses the extended identifier or not
+    return: value of the Identifier of the message
+*/
+uint32_t Canmsg::GetFullId() const
+{
+  if(this->isExtIdentifier)
+  {
+    return ((this->stdIdentifier<<18)|this->extIdentifier);
+  }
+  else
+  {
+    return this->stdIdentifier;
+  }
 }
 
 /* 

--- a/CanLogger/src/main.cpp
+++ b/CanLogger/src/main.cpp
@@ -30,7 +30,7 @@ void setup() {
   screenBufferInit();
   display.init();
 
-  if((CanUtility_Init() != HAL_OK) || (CanUtility_EnableRecieve() != HAL_OK))
+  if((CanUtility_Init(CAN_500_KBIT) != HAL_OK) || (CanUtility_EnableRecieve() != HAL_OK))
   {
     while(1){}
   }
@@ -46,7 +46,7 @@ void setup() {
 void loop() {
   loopTaster();
   pageManager.loop();
-  
+  loopScreenBuffer();
 }
 
 void serialEvent() {

--- a/CanLogger/src/utilities/utilities.cpp
+++ b/CanLogger/src/utilities/utilities.cpp
@@ -1,31 +1,5 @@
 #include "display/screenBuffer.hpp"
-#include "can/Canmsg.hpp"
 #include <Arduino.h>
-
-/* 
-    function that processes the last message of the "Canmsg_bufferCanRecMessages"
-*/
-void processCanMessage(void)
-{
-  Canmsg_bufferCanRecPointer--;
-  Canmsg curMsg = std::move(Canmsg_bufferCanRecMessages[Canmsg_bufferCanRecPointer]);
-  
-  //screenBuffer:
-  sortCanMessageIntoBuffer(curMsg);
-
-  //SD-Card:
-
-  //loopback:
-  /*
-  Canmsg_bufferCanRecMessages[Canmsg_bufferCanRecPointer].Send();
-  */
-
-  //Serial:
-  /*
-  Serial.print("Empfangene Nachricht: ");
-  Serial.println(static_cast<String>(Canmsg_bufferCanRecMessages[Canmsg_bufferCanRecPointer]));
-  */
-}
 
 /* 
     function to add zeros to a String that every String will have the same ammount of chars


### PR DESCRIPTION
Umstellen der CAN Dateien und screenBuffer auf scom

Funktion zum erfassen des gesamten Identifiers der CAN-Nachrichten, egal ob extended genutzt wird oder nicht

Der CAN Baustein kann auf verschiedene Busgeschwindigkeiten eingestellt werden.

processCanMessage wurde entfernt und in loopScreenBuffer verarbeitet und erweitert um zyklische aufrufe dieser Funktion zu ermöglichen